### PR TITLE
Fixed indexing errors thrown by numpy v1.12

### DIFF
--- a/rf_pipelines/transforms/badchannel_mask.py
+++ b/rf_pipelines/transforms/badchannel_mask.py
@@ -76,6 +76,7 @@ class badchannel_mask(rf_pipelines.py_wi_transform):
         # so they can be fed as indexes into the weights array.
         self.index_mask[:,0] = (np.ceil(self.index_mask[:,0])).astype(int)
         self.index_mask[:,1] = (np.floor(self.index_mask[:,1])).astype(int)
+        self.index_mask = self.index_mask.astype(int)
 
         # This line is to make sure that we don't use negative
         # indexes in the lower bound. Numpy arrays however accept

--- a/rf_pipelines/transforms/bonsai_dedisperser.py
+++ b/rf_pipelines/transforms/bonsai_dedisperser.py
@@ -125,7 +125,7 @@ class bonsai_dedisperser(rf_pipelines.py_wi_transform):
         if self.make_plot:
             self.buf = np.zeros((self.n_zoom, self.img_ndm, self.img_nt), dtype=np.float32)
             self.isubstream = isubstream
-            self.ifile = np.zeros((self.n_zoom))    # keeps track of which png file we're accumulating 
+            self.ifile = np.zeros((self.n_zoom), int)    # keeps track of which png file we're accumulating 
             self.ipos = np.zeros((self.n_zoom), int)     # keeps track of how many (downsampled) time samples have been accumulated into file so far
 
 

--- a/rf_pipelines/transforms/bonsai_dedisperser.py
+++ b/rf_pipelines/transforms/bonsai_dedisperser.py
@@ -126,7 +126,7 @@ class bonsai_dedisperser(rf_pipelines.py_wi_transform):
             self.buf = np.zeros((self.n_zoom, self.img_ndm, self.img_nt), dtype=np.float32)
             self.isubstream = isubstream
             self.ifile = np.zeros((self.n_zoom))    # keeps track of which png file we're accumulating 
-            self.ipos = np.zeros((self.n_zoom))     # keeps track of how many (downsampled) time samples have been accumulated into file so far
+            self.ipos = np.zeros((self.n_zoom), int)     # keeps track of how many (downsampled) time samples have been accumulated into file so far
 
 
     def process_chunk(self, t0, t1, intensity, weights, pp_intensity, pp_weights):

--- a/rf_pipelines/transforms/plotter_transform.py
+++ b/rf_pipelines/transforms/plotter_transform.py
@@ -108,7 +108,7 @@ class plotter_transform(rf_pipelines.py_wi_transform):
         self.intensity_buf = np.zeros((self.n_zoom, self.img_nfreq, self.img_nt), dtype=np.float32)
         self.weight_buf = np.zeros((self.n_zoom, self.img_nfreq, self.img_nt), dtype=np.float32)
         self.isubstream = isubstream
-        self.ifile = np.zeros((self.n_zoom))    # keeps track of which png file we're accumulating
+        self.ifile = np.zeros((self.n_zoom), int)    # keeps track of which png file we're accumulating
         self.ipos = np.zeros((self.n_zoom), int)     # keeps track of how many (downsampled) time samples have been accumulated into file so far
 
 

--- a/rf_pipelines/transforms/plotter_transform.py
+++ b/rf_pipelines/transforms/plotter_transform.py
@@ -109,7 +109,7 @@ class plotter_transform(rf_pipelines.py_wi_transform):
         self.weight_buf = np.zeros((self.n_zoom, self.img_nfreq, self.img_nt), dtype=np.float32)
         self.isubstream = isubstream
         self.ifile = np.zeros((self.n_zoom))    # keeps track of which png file we're accumulating
-        self.ipos = np.zeros((self.n_zoom))     # keeps track of how many (downsampled) time samples have been accumulated into file so far
+        self.ipos = np.zeros((self.n_zoom), int)     # keeps track of how many (downsampled) time samples have been accumulated into file so far
 
 
     def process_chunk(self, t0, t1, intensity, weights, pp_intensity, pp_weights):


### PR DESCRIPTION
There may be others, but these are the three I needed to fix to run the ch_frb_rfi examples.  The problem was numpy arrays with non-integer dtypes that were used for indexing, which was allowed in older numpy versions.