### PR TITLE
Add a transform that records how many data samples are masked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ OFILES = badchannel_mask.o \
 	spectrum_analyzer.o \
 	spline_detrenders.o \
 	std_dev_clippers.o \
+	mask_counter.o \
 	wi_sub_pipeline.o \
 	wi_stream.o \
 	wi_transform.o \

--- a/mask_counter.cpp
+++ b/mask_counter.cpp
@@ -1,0 +1,124 @@
+#include "rf_pipelines_internals.hpp"
+
+using namespace std;
+
+namespace rf_pipelines {
+#if 0
+}; // pacify emacs c-mode
+#endif
+
+
+struct mask_counter_transform : public wi_transform 
+{
+    //const rf_kernels::axis_type axis;
+    //unique_ptr<rf_kernels::std_dev_clipper> kernel;
+
+    mask_counter_transform(int nt_chunk_) :
+        wi_transform("mask_counter")
+        //axis(axis_),
+    {	
+        stringstream ss;
+        ss << "mask_counter(nt_chunk=" << nt_chunk_ << ")";
+        this->name = ss.str();
+        this->nt_chunk = nt_chunk_;
+        //this->kernel_chunk_size = 8*Dt;
+        this->nds = 0;  // allows us to run in a wi_sub_pipeline
+
+        if (nt_chunk == 0)
+            throw runtime_error("rf_pipelines::mask_counter: nt_chunk must be specified");
+	
+        // Can't construct the kernel yet, since 'nfreq' is not known until set_stream()
+    }
+
+    virtual ~mask_counter_transform() { }
+
+    // Called after (nfreq, nds) are initialized.
+    virtual void _bind_transform(Json::Value &json_attrs) override
+    {
+        //this->kernel = make_unique<rf_kernels::mask_counter> (nfreq, xdiv(nt_chunk,nds), axis, sigma, Df, Dt, two_pass);
+    }
+
+    virtual void _process_chunk(float *intensity, ssize_t istride, float *weights, ssize_t wstride, ssize_t pos) override
+    {
+        cout << "mask_counters process_chunk" << endl;
+        //this->kernel->clip(intensity, istride, weights, wstride);
+        // _process_chunk(intensity, istride, weights, wstride, pos)
+        //
+        //    This is the "core" method which is responsible for processing the 'intensity' and 'weights'
+        //    arrays over timestamp range [pos,pos+nt_chunk).  The array strides are istride/wstride, 
+        //    i.e. the (i,j)-th element of the intensity  array is intensity[i*istride+j], and similarly 
+        //    for the weights.
+        //
+        //    Transforms which support downsampling (i.e. nds > 1) should note that 'pos'
+        //    and 'nt_chunk' do not have the downsampling factor applied, but array dimensions
+        //    do.  That is, the 'intensity' and 'weights' arrays have shape (nfreq, nt_chunk/nds),
+        //    not shape (nfreq, nt_chunk), and 'pos' increases by nt_chunk (not nt_chunk/nds)
+        //    in each call to _process_chunk();
+        int nt = nt_chunk/nds;
+        bool*  any_unmasked_f = (bool*)malloc(nfreq);
+        memset(any_unmasked_f, 0, nfreq);
+        bool*  any_unmasked_t = (bool*)malloc(nt);
+        memset(any_unmasked_t, 0, nt);
+
+        int nmasked = 0;
+
+        for (int i_f=0; i_f<nfreq; i_f++) {
+            for (int i_t=0; i_t<nt; i_t++) {
+                if (weights[i_f*wstride + i_t] == 0) {
+                    nmasked++;
+                } else {
+                    any_unmasked_f[i_f] = true;
+                    any_unmasked_t[i_t] = true;
+                }
+            }
+        }
+
+        int nfmasked = 0;
+        int ntmasked = 0;
+        for (int i=0; i<nfreq; i++)
+            if (!any_unmasked_f[i])
+                nfmasked++;
+        for (int i=0; i<nt; i++)
+            if (!any_unmasked_t[i])
+                ntmasked++;
+
+        cout << "N samples masked: " << nmasked << "; n times " << ntmasked << "; n freqs " << nfmasked << endl;
+
+        free(any_unmasked_f);
+        free(any_unmasked_t);
+    }
+
+    virtual Json::Value jsonize() const override
+    {
+        Json::Value ret;
+
+        ret["class_name"] = "mask_counter";
+        ret["nt_chunk"] = int(this->get_prebind_nt_chunk());
+	
+        return ret;
+    }
+
+    static shared_ptr<mask_counter_transform> from_json(const Json::Value &j)
+    {
+        ssize_t nt_chunk = ssize_t_from_json(j, "nt_chunk");
+        return make_shared<mask_counter_transform> (nt_chunk);
+    }
+};
+
+
+namespace {
+    struct _init {
+        _init() {
+            pipeline_object::register_json_deserializer("mask_counter", mask_counter_transform::from_json);
+        }
+    } init;
+}
+
+// Externally callable
+shared_ptr<wi_transform> make_mask_counter(int nt_chunk)
+{
+    return make_shared<mask_counter_transform> (nt_chunk);
+}
+
+
+}  // namespace rf_pipelines

--- a/mask_counter.cpp
+++ b/mask_counter.cpp
@@ -53,9 +53,14 @@ void mask_counter_transform::_process_chunk(float *intensity, ssize_t istride, f
         meas.nsamples = nfreq*nt;
         meas.nt = nt;
         meas.nf = nfreq;
-
         meas.nsamples_masked = 0;
         meas.nf_masked = 0;
+
+        meas.freqs_masked = shared_ptr<bool>((bool*)calloc(nfreq, 1), free);
+        meas.times_masked = shared_ptr<bool>((bool*)calloc(nt,    1), free);
+
+        bool* fm = meas.freqs_masked.get();
+        bool* tm = meas.times_masked.get();
 
         for (int i_f=0; i_f<nfreq; i_f++) {
             bool allmasked = true;
@@ -67,14 +72,18 @@ void mask_counter_transform::_process_chunk(float *intensity, ssize_t istride, f
                     any_unmasked_t[i_t] = true;
                 }
             }
-            if (allmasked)
+            if (allmasked) {
                 meas.nf_masked++;
+                fm[i_f] = true;
+            }
         }
 
         meas.nt_masked = 0;
         for (int i=0; i<nt; i++)
-            if (!any_unmasked_t[i])
+            if (!any_unmasked_t[i]) {
                 meas.nt_masked++;
+                tm[i] = true;
+            }
 
         cout << "pos " << pos << ": N samples masked: " << meas.nsamples_masked << "/" << (meas.nsamples) << "; n times " << meas.nt_masked << "/" << meas.nt << "; n freqs " << meas.nf_masked << "/" << meas.nf << endl;
 

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -507,6 +507,8 @@ struct mask_counter_measurements {
     int nt_masked;
     int nf;
     int nf_masked;
+    std::shared_ptr<bool> freqs_masked;
+    std::shared_ptr<bool> times_masked;
 };
 
 class mask_counter_callback {
@@ -528,7 +530,7 @@ struct mask_counter_transform : public wi_transform {
     virtual void _process_chunk(float *intensity, ssize_t istride, float *weights, ssize_t wstride, ssize_t pos) override;
     virtual Json::Value jsonize() const override;
     static std::shared_ptr<mask_counter_transform> from_json(const Json::Value &j);
-    
+
     void add_callback(const std::shared_ptr<mask_counter_callback> cb);
     void remove_callback(const std::shared_ptr<mask_counter_callback> cb);
 };

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -518,10 +518,11 @@ public:
 // We expose more details than we typically would because external
 // users need to register a callback.
 struct mask_counter_transform : public wi_transform {
+    std::string where;
     std::unique_ptr<bool[]> any_unmasked_t;
     std::vector<std::shared_ptr<mask_counter_callback> > callbacks;
 
-    mask_counter_transform(int nt_chunk_);
+    mask_counter_transform(int nt_chunk_, std::string where_);
     virtual ~mask_counter_transform() { }
     virtual void _bind_transform(Json::Value &json_attrs) override;
     virtual void _process_chunk(float *intensity, ssize_t istride, float *weights, ssize_t wstride, ssize_t pos) override;
@@ -533,7 +534,7 @@ struct mask_counter_transform : public wi_transform {
 };
 
 // Externally callable
-std::shared_ptr<wi_transform> make_mask_counter(int nt_chunk);
+std::shared_ptr<wi_transform> make_mask_counter(int nt_chunk, std::string where);
 
 
 

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -507,8 +507,10 @@ struct mask_counter_measurements {
     int nt_masked;
     int nf;
     int nf_masked;
-    std::shared_ptr<bool> freqs_masked;
-    std::shared_ptr<bool> times_masked;
+    // For each frequency, how many of the "nt" samples are masked?
+    std::shared_ptr<uint16_t> freqs_masked;
+    // For each time, how many of the "nf" samples are masked?
+    std::shared_ptr<uint16_t> times_masked;
 };
 
 class mask_counter_callback {
@@ -521,7 +523,6 @@ public:
 // users need to register a callback.
 struct mask_counter_transform : public wi_transform {
     std::string where;
-    std::unique_ptr<bool[]> any_unmasked_t;
     std::vector<std::shared_ptr<mask_counter_callback> > callbacks;
 
     mask_counter_transform(int nt_chunk_, std::string where_);


### PR DESCRIPTION
- add mask_counter_transform

Currently, this callocs two buffers for each second of data -- not sure what performance impact that has.
