### PR TITLE
add frame0_nano to the JSON that eventually becomes L1b's opaque_context

### DIFF
--- a/chime_network_stream.cpp
+++ b/chime_network_stream.cpp
@@ -114,6 +114,7 @@ void chime_network_stream::_start_pipeline(Json::Value &j)
     uint64_t fpga0 = uint64_t(first_chunk->isample) * uint64_t(first_chunk->fpga_counts_per_sample);
     
     j["initial_fpga_count"] = Json::UInt64(fpga0);
+    j["frame0_nano"] = Json::UInt64(first_chunk->frame0_nano);
     j["fpga_counts_per_sample"] = first_chunk->fpga_counts_per_sample;
 }
 


### PR DESCRIPTION
This allows L1b to know about the real time that the FPGAs started, and therefore convert FPGA counts into seconds since 1970.0

There are corresponding PRs in ch_frb_io and ch_frb_l1.
