### PR TITLE
RFI mask monitoring: add get_summed_measurements

### DIFF
--- a/mask_measurements_ringbuf.cpp
+++ b/mask_measurements_ringbuf.cpp
@@ -73,11 +73,9 @@ mask_measurements_ringbuf::get_summed_measurements(ssize_t pos_min, ssize_t pos_
         if (next <= maxsize) {
             start = 0;
             end = next;
-            cout << "get_summed_measurements: ring buffer not full yet; " << start << " to " << end << endl;
         } else {
             start = next;
             end = next + maxsize;
-            cout << "get_summed_measurements: ring buffer full; " << start << " to " << end << " (mod " << (start % maxsize) << " to " << (end % maxsize) << ")" << endl;
         }
         for (int i=start; i<end; i++) {
             const mask_measurements& m = ringbuf[i % maxsize];
@@ -85,7 +83,7 @@ mask_measurements_ringbuf::get_summed_measurements(ssize_t pos_min, ssize_t pos_
                 continue;
             if (m.pos >= pos_max)
                 continue;
-            cout << "get_summed_measurements: adding " << m.pos << " to " << (m.pos + m.nt) << endl;
+            //cout << "get_summed_measurements: adding " << m.pos << " to " << (m.pos + m.nt) << endl;
             if (!meas_sum)
                 meas_sum = make_shared<mask_measurements>(m.pos, m.nf, m.nt);
             else {

--- a/mask_measurements_ringbuf.cpp
+++ b/mask_measurements_ringbuf.cpp
@@ -47,18 +47,16 @@ mask_measurements_ringbuf::get_all_measurements() {
         int start;
         int end;
         if (next <= maxsize) {
+            // ring buffer not yet full
             start = 0;
             end = next;
-            cout << "get_all_measurements: ring buffer not full yet; " << start << " to " << end << endl;
         } else {
             start = next;
             end = next + maxsize;
-            cout << "get_all_measurements: ring buffer full; " << start << " to " << end << " (mod " << (start % maxsize) << " to " << (end % maxsize) << ")" << endl;
         }
         for (int i=start; i<end; i++)
             copy.push_back(ringbuf[i % maxsize]);
     }
-    cout << "get_all_measurements: return " << copy.size() << endl;
     return copy;
 }
 
@@ -85,8 +83,10 @@ mask_measurements_ringbuf::get_summed_measurements(ssize_t pos_min, ssize_t pos_
                 continue;
             //cout << "get_summed_measurements: adding " << m.pos << " to " << (m.pos + m.nt) << endl;
             if (!meas_sum)
+                // create
                 meas_sum = make_shared<mask_measurements>(m.pos, m.nf, m.nt);
             else {
+                // accumulate
                 meas_sum->nt += m.nt;
                 meas_sum->nsamples += m.nsamples;
             }

--- a/mask_measurements_ringbuf.cpp
+++ b/mask_measurements_ringbuf.cpp
@@ -81,7 +81,7 @@ mask_measurements_ringbuf::get_summed_measurements(ssize_t pos_min, ssize_t pos_
         }
         for (int i=start; i<end; i++) {
             const mask_measurements& m = ringbuf[i % maxsize];
-            if ((m.pos + m.nt) < pos_min)
+            if ((m.pos + m.nt) <= pos_min)
                 continue;
             if (m.pos >= pos_max)
                 continue;

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -583,6 +583,8 @@ public:
     std::unordered_map<std::string, float> get_stats(int nchunks);
     std::vector<rf_pipelines::mask_measurements> get_all_measurements();
 
+    std::shared_ptr<rf_pipelines::mask_measurements> get_summed_measurements(ssize_t pos_min, ssize_t pos_max);
+    
     void add(rf_pipelines::mask_measurements& meas);
 
 protected:

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -581,10 +581,17 @@ public:
     mask_measurements_ringbuf(int nhistory=300);
 
     std::unordered_map<std::string, float> get_stats(int nchunks);
+
+    // Returns all measurements from this ring buffer, in time order.
     std::vector<rf_pipelines::mask_measurements> get_all_measurements();
 
+    // Returns a mask_measurement object that sums up the number of masked
+    // samples from the given range of time samples in the ring buffer.
+    // *pos_min* and *pos_max* are time indices in the pipeline, and any
+    // chunk of data that overlaps the range will be included in the sum.
     std::shared_ptr<rf_pipelines::mask_measurements> get_summed_measurements(ssize_t pos_min, ssize_t pos_max);
-    
+
+    // Inserts a measurement into this ring buffer.
     void add(rf_pipelines::mask_measurements& meas);
 
 protected:


### PR DESCRIPTION
This adds an accessor to the mask_measurement_ringbuf to retrieve the summed measurements from a range of times.
