### PR TITLE
Add "name" and "source" attributes to chime_slow_pulsar_writer and its pstate, respectively

### DIFF
--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -135,8 +135,6 @@ void chime_slow_pulsar_writer::set_params(const ssize_t beam_id, const ssize_t n
 
         pstate->nsamp = pstate->nfreq_out * pstate->ntime_out;
 
-        chlog("Slow pulsar downswampler: " << pstate->downsampler << std::endl);
-
         // TODO check parameter consistency with existing file_header?
         pstate->nbins = nbins;
 

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -674,7 +674,7 @@ shared_ptr<chime_slow_pulsar_writer> chime_slow_pulsar_writer::from_json(const J
 
     key = "name";
     if (j.isMember(key))
-+        name = j[key].asString();
+        name = j[key].asString();
     key = "nfreq_out";
     if (j.isMember(key))
         nfreq_out = j[key].asInt();

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -24,11 +24,12 @@ struct chime_slow_pulsar_context
 
 };
 
-chime_slow_pulsar_writer::chime_slow_pulsar_writer(ssize_t nt_chunk_) :
-    wi_transform("chime_slow_pulsar_writer")
+chime_slow_pulsar_writer::chime_slow_pulsar_writer(ssize_t nt_chunk_, const std::string &name_) :
+    wi_transform("chime_slow_pulsar_writer", name_)
 {
     // Note: nt_chunk is defined in wi_transform base class.
     this->nt_chunk = nt_chunk_;
+    this->name = name_;
     const ssize_t ntime_max = 4096;
     const ssize_t nfreq_max = 16384;
     const ssize_t nsamp_max = nfreq_max * ntime_max;
@@ -94,7 +95,7 @@ void chime_slow_pulsar_writer::init_real_time_state(const real_time_state &rt_st
 
 
 void chime_slow_pulsar_writer::set_params(const ssize_t beam_id, const ssize_t nfreq_out, 
-					  const ssize_t ntime_out, const ssize_t nbins, std::shared_ptr<std::string> base_path)
+					  const ssize_t ntime_out, const ssize_t nbins, std::shared_ptr<std::string> base_path, std::shared_ptr<std::string> source)
 { 
     // FIXME add more asserts here
     rf_assert(beam_id == this->beam_id);
@@ -117,6 +118,7 @@ void chime_slow_pulsar_writer::set_params(const ssize_t beam_id, const ssize_t n
         
         // forgo checks on path validity for now
         pstate->base_path = base_path;
+        pstate->source = source;
 
         pstate->nfreq_out = nfreq_out;
         pstate->ntime_out = ntime_out;
@@ -132,6 +134,8 @@ void chime_slow_pulsar_writer::set_params(const ssize_t beam_id, const ssize_t n
                                                    pstate->nds_freq, pstate->nds_time));
 
         pstate->nsamp = pstate->nfreq_out * pstate->ntime_out;
+
+        chlog("Slow pulsar downswampler: " << pstate->downsampler << std::endl);
 
         // TODO check parameter consistency with existing file_header?
         pstate->nbins = nbins;
@@ -665,7 +669,15 @@ shared_ptr<chime_slow_pulsar_writer> chime_slow_pulsar_writer::from_json(const J
     ssize_t ntime_out = 0;
     ssize_t nbins = 0;
     string base_path = "";
-    string key = "nfreq_out";
+    string source = "";
+    string name = "";
+
+    string key = "";
+
+    key = "name";
+    if (j.isMember(key))
++        name = j[key].asString();
+    key = "nfreq_out";
     if (j.isMember(key))
         nfreq_out = j[key].asInt();
     key = "ntime_out";
@@ -677,10 +689,13 @@ shared_ptr<chime_slow_pulsar_writer> chime_slow_pulsar_writer::from_json(const J
     key = "base_path";
     if (j.isMember(key))
         base_path = j[key].asString();
+    key = "source";
+    if (j.isMember(key))
+        source = j[key].asString();
 
-    auto sps = make_shared<chime_slow_pulsar_writer> (nt_chunk);
+    auto sps = make_shared<chime_slow_pulsar_writer> (nt_chunk, name);
 
-    if ((base_path.size() > 0) && (nfreq_out > 0) && (ntime_out > 0) && (nbins > 0))
+    if ((base_path.size() > 0) && (source.size() > 0) && (nfreq_out > 0) && (ntime_out > 0) && (nbins > 0))
 	cout << "FIXME: ignoring initial_params for now" << endl;
 
     return sps;

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -727,6 +727,7 @@ struct chime_slow_pulsar_writer : public wi_transform
 
     struct param_state{
         std::shared_ptr<std::string> base_path;
+        std::shared_ptr<std::string> source;
         std::shared_ptr<rf_kernels::wi_downsampler> downsampler;
         // std::shared_ptr<ch_frb_io::intensity_network_stream> stream;
         ssize_t beam_id = -1;
@@ -790,17 +791,17 @@ struct chime_slow_pulsar_writer : public wi_transform
     
     real_time_state rt_state;
 
-    chime_slow_pulsar_writer(ssize_t nt_chunk);
+    chime_slow_pulsar_writer(ssize_t nt_chunk, const std::string &name);
 
     // Called by RPC thread, once during initialization.
     void init_real_time_state(const real_time_state &rt_state);
 
     // Called by RPC thread, intermittently while pipeline is running.
     // void set_params(const ssize_t beam_id, const ssize_t ibeam, const ssize_t nfreq, 
-    //                 const ssize_t ntime, const ssize_t nbins, std::shared_ptr<std::string> base_path
+    //                 const ssize_t ntime, const ssize_t nbins, std::shared_ptr<std::string> base_path, std::shared_ptr<std::string> source
     //                 std::shared_ptr<ch_frb_io::intensity_network_stream> stream);
     void set_params(const ssize_t beam_id, const ssize_t nfreq_out, 
-		    const ssize_t ntime_out, const ssize_t nbins, std::shared_ptr<std::string> base_path);
+		    const ssize_t ntime_out, const ssize_t nbins, std::shared_ptr<std::string> base_path, std::shared_ptr<std::string> source);
 
     // Called interally to populate and write an sp_file_header to tmp_buf
     void _update_file_header_with_lock();


### PR DESCRIPTION
"name" corresponds to an attribute added to the RFI configs to define pre-empetively 2 (instead of 1) chime_slow_pulsar_writer objects ("name" is already an acceptable parameter of wi_transform which is used to parse the RFI configs, so I thought it makes sense to use that).

"source" is the RPC call parameter to define which chime_slow_pulsar_writer is modified in the hash table ("CHAMPSS" or "Slow") for the same beam.

Relevant PRs:
https://github.com/kmsmith137/ch_frb_l1/pull/45
https://github.com/mrafieir/ch_frb_rfi/pull/10

Currently being tested and run on `cfdn1` under "sps-slow-test".

@dstndstn 