### PR TITLE
Fix mean and variance calculation in chime_slow_pulsar_writer

### DIFF
--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -495,20 +495,9 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             const __m256 ndss_corr = _mm256_set1_ps(nds_tot-1);
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
-                const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
-                // const __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
-                __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
-                // Create array which is 1 for values with full weight and 0 otherwise
-                mmask = _mm256_sub_ps(mmask, ndss_corr);
-                mmask = _mm256_max_ps(mmask, zeroes);
-                // Ideally would perform early stopping if mmask only contains 0, but did not find fast operation
-                ms0 = _mm256_mul_ps(mvari, mmask);
-                ms1 = _mm256_add_ps(ms0, ms1);
-                ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);
-                ms3 = _mm256_add_ps(mmask, ms3);
-
                 // compute mask
-                __m256i mvarw = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
+                __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
+                __m256i mvarw = _mm256_cvtps_epi32(mmask);
                 mvarw = _mm256_srlv_epi32(mvarw, shift_ds); // divide by downsampling factor
                 mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift0), 177));
                 mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
@@ -528,6 +517,21 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 // std::bitset<8> y((uint8_t) mask_byte);
                 // // std::cout << "wut2" << endl;
                 // std::cout << (((uint8_t) tmp_intrin[0]) - mask_byte) << " " << x << " " << y << " " << ((uint32_t) ((uint8_t) tmp_intrin[0])) << " " << ((uint32_t) mask_byte) << std::endl;
+
+                // tmp[0] will be 0 for fully masked frames, which allows skipping those iterations
+                if (tmp0[0] == 0){continue;}
+
+                // compute means and squares
+                const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
+                // Create array which is 1 for values with full weight and 0 otherwise
+                mmask = _mm256_sub_ps(mmask, ndss_corr);
+                mmask = _mm256_max_ps(mmask, zeroes);
+                // Multiply with mask in order to ignore masked values
+                ms0 = _mm256_mul_ps(mvari, mmask);
+                ms1 = _mm256_add_ps(ms0, ms1);
+                ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);
+                // Get number of unmasked bins
+                ms3 = _mm256_add_ps(mmask, ms3);
             }
 
             _mm256_store_ps(tmp1, ms1);

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -491,12 +491,12 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             const __m256i shift0 = _mm256_set_epi32(1,1,1,1,1,1,1,1);
             const __m256i shift1 = _mm256_set_epi32(2,2,2,2,2,2,2,2);
             const __m256i shift2 = _mm256_set_epi32(4,4,4,4,4,4,4,4);
-            __m256 ones = _mm256_set1_ps(1.);
+            const __m256 ones = _mm256_set1_ps(1.);
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
                 const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
                 // const __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
-                __m256 mmask = _mm256_load_ps(mask + itime_o);
+                __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
                 mmask = _mm256_min_ps(mmask, ones);
                 ms0 = _mm256_mul_ps(mvari, mmask);
                 ms1 = _mm256_add_ps(ms0, ms1);

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -530,13 +530,13 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             for(ssize_t i = 0; i < 8; i++){
                 s1 += tmp1[i];
                 s2 += tmp2[i];
-                s2 += tmp3[i];
+                s3 += tmp3[i];
             }
 
             // Repeat calculation with old scheme if full chunk is masked
             // Could also calculate if chunk if fully masked before the full loop
             // Performance of alternate scheme most likely depends on fraction of fully masked chunks
-            if (s3 == 0){
+            if (s3 == 0.){
                 s1 = 0.;
                 s2 = 0.;
                 __m256 ms0 = _mm256_set1_ps(0.);
@@ -553,26 +553,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                     s1 += tmp1[i];
                     s2 += tmp2[i];
                 }
-                s3 = ntime_out;
-            }
-            if (s3 == 0){
-                s1 = 0.;
-                s2 = 0.;
-                __m256 ms0 = _mm256_set1_ps(0.);
-                __m256 ms1 = _mm256_set1_ps(0.);
-                for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
-                    const ssize_t itime_o = iframe_o * 8;
-                    const __m256 mvari = _mm256_load_ps(intensity + itime_o);
-                    ms1 = _mm256_add_ps(mvari, ms1);
-                    ms2 = _mm256_fmadd_ps(mvari, mvari, ms2);
-                    }
-                    _mm256_store_ps(tmp1, ms1);
-                    _mm256_store_ps(tmp2, ms2);
-                    s3 = float(pstate->ntime_out);
-                    for(ssize_t i = 0; i < 8; i++){
-                        s1 += tmp1[i];
-                        s2 += tmp2[i];
-                    }
+                s3 = float(ntime_out);
             }
 
             // auto t22 = std::chrono::high_resolution_clock::now();

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -443,44 +443,6 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             ssize_t ibit_w = 0;
             uint8_t* mask_tmp_ar = get_ptr<uint8_t>(tmp_mask);
 
-            // auto t21 = std::chrono::high_resolution_clock::now();
-            // for(ssize_t itime = 0; itime < pstate->ntime_out; itime++){
-            //     const float v = ds_ic[ifreq * istridec + itime];
-            //     s1 += v;
-            //     s2 += v*v;
-
-            //     // this is a particularly inelegant solution
-            //     // TODO: FIX
-            //     float w = ds_wc[ifreq * wstridec + itime];
-            //     // std::cout << w << std::endl;
-            //     mask_byte += ((uint8_t) w) << ibit_w;
-
-            //     ibit_w++;
-            //     if(ibit_w == 8){
-            //         ibit_w = 0;
-            //         ibyte_w += 1;
-            //         (*tmp_mask)[ifreq * nrow_mask + ibyte_w] = mask_byte;
-            //         mask_byte = 0;
-            //     }
-            // }
-
-            // for(ssize_t itime_o = 0; itime_o < pstate->ntime_out; itime_o+=8){
-            //     uint8_t mask_byte = 0;
-            //     const ssize_t iind = ifreq * istridec + itime_o;
-            //     const ssize_t wind = ifreq * wstridec + itime_o;
-            //     for(ssize_t itime_i = 0; itime_i < 8; itime_i++){
-            //         const float v = ds_ic[iind + itime_i];
-            //         s1 += v;
-            //         s2 += v*v;
-
-            //         // this is a particularly inelegant solution
-            //         // TODO: FIX
-            //         const float w = ds_wc[wind + itime_i];
-            //         // std::cout << w << std::endl;
-            //         mask_byte += ((uint8_t) w) << itime_i;
-            //     }
-            //     mask_tmp_ar[ifreq * nrow_mask + itime_o] = mask_byte;
-            // }
             __m256 ms0 = _mm256_set1_ps(0.);
             __m256 ms1 = _mm256_set1_ps(0.);
             __m256 ms2 = _mm256_set1_ps(0.);
@@ -491,31 +453,21 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             const __m256i shift0 = _mm256_set_epi32(1,1,1,1,1,1,1,1);
             const __m256i shift1 = _mm256_set_epi32(2,2,2,2,2,2,2,2);
             const __m256i shift2 = _mm256_set_epi32(4,4,4,4,4,4,4,4);
-            const __m256 zeroes = _mm256_set1_ps(0.);
-            const __m256 ndss_corr = _mm256_set1_ps(nds_tot-1);
+
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
                 // compute mask
                 __m256i mmask_i = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
                 mmask_i = _mm256_srlv_epi32(mmask_i, shift_ds); // divide by downsampling factor
+                // The add and shuffle operations will sum all 8 values into the first entry.
+                // The _mm256_sllv_epi32 operation will shift the value so that each bit in the resulting mask value
+                // represents one of the 8 input values.
                 __m256i mvarw = _mm256_add_epi32(mmask_i, _mm256_shuffle_epi32(_mm256_sllv_epi32(mmask_i, shift0), 177));
                 mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
                 mvarw = _mm256_add_epi32(mvarw, _mm256_sllv_epi32(_mm256_permute2f128_si256(mvarw, mvarw, 1), shift2));
 
                 _mm256_store_si256((__m256i*) tmp0, mvarw);
-                // uint8_t mask_byte = 0;
-                // for(ssize_t itime_i = 0; itime_i < 8; itime_i++){
-                    // const uint8_t w = ((uint8_t) ds_wc[itime_o + itime_i]) / (nds_tot);
-                    // mask_byte += ((uint8_t) w) << itime_i;
-                // }
-                // std::cout << std::endl;
-
                 mask_tmp_ar[ifreq * nrow_mask + iframe_o] = (uint8_t) tmp0[0];
-                // mask_tmp_ar[ifreq * nrow_mask + itime_o] = mask_byte;
-                // std::bitset<8> x((uint8_t) tmp_intrin[0]);
-                // std::bitset<8> y((uint8_t) mask_byte);
-                // // std::cout << "wut2" << endl;
-                // std::cout << (((uint8_t) tmp_intrin[0]) - mask_byte) << " " << x << " " << y << " " << ((uint32_t) ((uint8_t) tmp_intrin[0])) << " " << ((uint32_t) mask_byte) << std::endl;
 
                 // tmp[0] will be 0 for fully masked frames, which allows skipping those iterations
                 if (tmp0[0] == 0){continue;}
@@ -542,7 +494,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 s3 += tmp3[i];
             }
 
-            // Repeat calculation including also masked values if full chunk is masked
+            // Repeat calculation including masked values if full chunk is masked
             if (s3 == 0.){
                 s1 = 0.;
                 s2 = 0.;

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -496,10 +496,9 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
                 // compute mask
-                __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
-                __m256i mvarw = _mm256_cvtps_epi32(mmask);
-                mvarw = _mm256_srlv_epi32(mvarw, shift_ds); // divide by downsampling factor
-                mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift0), 177));
+                __m256i mmask_i = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
+                mmask_i = _mm256_srlv_epi32(mmask_i, shift_ds); // divide by downsampling factor
+                __m256i mvarw = _mm256_add_epi32(mmask_i, _mm256_shuffle_epi32(_mm256_sllv_epi32(mmask_i, shift0), 177));
                 mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
                 mvarw = _mm256_add_epi32(mvarw, _mm256_sllv_epi32(_mm256_permute2f128_si256(mvarw, mvarw, 1), shift2));
 
@@ -523,15 +522,14 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
 
                 // compute means and squares
                 const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
-                // Create array which is 1 for values with full weight and 0 otherwise
-                mmask = _mm256_sub_ps(mmask, ndss_corr);
-                mmask = _mm256_max_ps(mmask, zeroes);
+                // convert integer mask to float
+                __m256 mmask_f = _mm256_cvtepi32_ps(mmask_i);
                 // Multiply with mask in order to ignore masked values
-                ms0 = _mm256_mul_ps(mvari, mmask);
+                ms0 = _mm256_mul_ps(mvari, mmask_f);
                 ms1 = _mm256_add_ps(ms0, ms1);
                 ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);
                 // Get number of unmasked bins
-                ms3 = _mm256_add_ps(mmask, ms3);
+                ms3 = _mm256_add_ps(mmask_f, ms3);
             }
 
             _mm256_store_ps(tmp1, ms1);
@@ -544,9 +542,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 s3 += tmp3[i];
             }
 
-            // Repeat calculation with old scheme if full chunk is masked
-            // Could also calculate if chunk if fully masked before the full loop
-            // Performance of alternate scheme most likely depends on fraction of fully masked chunks
+            // Repeat calculation including also masked values if full chunk is masked
             if (s3 == 0.){
                 s1 = 0.;
                 s2 = 0.;

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -493,8 +493,8 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             const __m256i shift2 = _mm256_set_epi32(4,4,4,4,4,4,4,4);
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
-                const __m256 mvari = _mm256_load_ps(intensity + itime_o);
-                const __m256 mmask = _mm256_load_ps(mask + itime_o);
+                const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
+                const __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
                 ms0 = _mm256_mul_ps(mvari, mmask);
                 ms1 = _mm256_add_ps(ms0, ms1);
                 ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);
@@ -543,7 +543,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 __m256 ms1 = _mm256_set1_ps(0.);
                 for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                     const ssize_t itime_o = iframe_o * 8;
-                    const __m256 mvari = _mm256_load_ps(intensity + itime_o);
+                    const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
                     ms1 = _mm256_add_ps(mvari, ms1);
                     ms2 = _mm256_fmadd_ps(mvari, mvari, ms2);
                     }

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -47,6 +47,7 @@ chime_slow_pulsar_writer::chime_slow_pulsar_writer(ssize_t nt_chunk_) :
     this->tmp_intrin = std::shared_ptr<uint32_t>(aligned_alloc<uint32_t>(8, 32, false), free);
     this->tmp_intrinf1 = std::shared_ptr<float>(aligned_alloc<float>(8, 32, false), free);
     this->tmp_intrinf2 = std::shared_ptr<float>(aligned_alloc<float>(8, 32, false), free);
+    this->tmp_intrinf3 = std::shared_ptr<float>(aligned_alloc<float>(8, 32, false), free);
 
     this->tmp_i = std::shared_ptr<float>(aligned_alloc<float>(nsamp_max, 32, false), free);
     this->tmp_w = std::shared_ptr<float>(aligned_alloc<float>(nsamp_max, 32, false), free);
@@ -410,6 +411,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
         uint32_t* tmp0 = get_ptr<uint32_t>(tmp_intrin);
         float* tmp1 = get_ptr<float>(tmp_intrinf1);
         float* tmp2 = get_ptr<float>(tmp_intrinf2);
+        float* tmp2 = get_ptr<float>(tmp_intrinf3);
         float fnorm;
 
         // estimate channel mean and var, compute mask
@@ -436,6 +438,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
 
             float s1 = 0.;
             float s2 = 0.;
+            float s3 = 0.;
             ssize_t ibyte_w = 0;
             ssize_t ibit_w = 0;
             uint8_t* mask_tmp_ar = get_ptr<uint8_t>(tmp_mask);
@@ -478,8 +481,10 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             //     }
             //     mask_tmp_ar[ifreq * nrow_mask + itime_o] = mask_byte;
             // }
+            __m256 ms0 = _mm256_set1_ps(0.);
             __m256 ms1 = _mm256_set1_ps(0.);
             __m256 ms2 = _mm256_set1_ps(0.);
+            __m256 ms3 = _mm256_set1_ps(0.);
             // const __m128i shift0 = _mm_set_epi32(1,1,1,1);
             const __m256i shift_ds = _mm256_set_epi32(log_nds_tot, log_nds_tot, log_nds_tot, log_nds_tot,
                                                       log_nds_tot, log_nds_tot, log_nds_tot, log_nds_tot);
@@ -488,18 +493,21 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             const __m256i shift2 = _mm256_set_epi32(4,4,4,4,4,4,4,4);
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
-                const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
-                ms1 = _mm256_add_ps(mvari, ms1);
-                ms2 = _mm256_fmadd_ps(mvari, mvari, ms2);
+                const __m256 mvari = _mm256_load_ps(intensity + itime_o);
+                const __m256 mmask = _mm256_load_ps(mask + itime_o);
+                ms0 = _mm256_mul_ps(mvari, mmask);
+                ms1 = _mm256_add_ps(ms0, ms1);
+                ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);
+                ms3 = _mm256_add_ps(mmask, ms3);
 
                 // compute mask
-                __m256i mvarw = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
-                mvarw = _mm256_srlv_epi32(mvarw, shift_ds); // divide by downsampling factor
-                mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift0), 177));
-                mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
-                mvarw = _mm256_add_epi32(mvarw, _mm256_sllv_epi32(_mm256_permute2f128_si256(mvarw, mvarw, 1), shift2));
+                // __m256i mvarw = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
+                // mvarw = _mm256_srlv_epi32(mvarw, shift_ds); // divide by downsampling factor
+                // mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift0), 177));
+                // mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
+                // mvarw = _mm256_add_epi32(mvarw, _mm256_sllv_epi32(_mm256_permute2f128_si256(mvarw, mvarw, 1), shift2));
 
-                _mm256_store_si256((__m256i*) tmp0, mvarw);
+                // _mm256_store_si256((__m256i*) tmp0, mvarw);
                 // uint8_t mask_byte = 0;
                 // for(ssize_t itime_i = 0; itime_i < 8; itime_i++){
                     // const uint8_t w = ((uint8_t) ds_wc[itime_o + itime_i]) / (nds_tot);
@@ -507,7 +515,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 // }
                 // std::cout << std::endl;
 
-                mask_tmp_ar[ifreq * nrow_mask + iframe_o] = (uint8_t) tmp0[0];
+                // mask_tmp_ar[ifreq * nrow_mask + iframe_o] = (uint8_t) tmp0[0];
                 // mask_tmp_ar[ifreq * nrow_mask + itime_o] = mask_byte;
                 // std::bitset<8> x((uint8_t) tmp_intrin[0]);
                 // std::bitset<8> y((uint8_t) mask_byte);
@@ -517,10 +525,54 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
 
             _mm256_store_ps(tmp1, ms1);
             _mm256_store_ps(tmp2, ms2);
+            _mm256_store_ps(tmp3, ms3);
 
             for(ssize_t i = 0; i < 8; i++){
                 s1 += tmp1[i];
                 s2 += tmp2[i];
+                s2 += tmp3[i];
+            }
+
+            // Repeat calvulation with old scheme if full chunk is masked
+            // Could also calculate if chunk if fully masked before the full loop
+            // Performance of alternate scheme most likely depends on fraction of fully masked chunks
+            if (s3 == 0){
+                s1 = 0.;
+                s2 = 0.;
+                __m256 ms0 = _mm256_set1_ps(0.);
+                __m256 ms1 = _mm256_set1_ps(0.);
+                for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
+                    const ssize_t itime_o = iframe_o * 8;
+                    const __m256 mvari = _mm256_load_ps(intensity + itime_o);
+                    ms1 = _mm256_add_ps(mvari, ms1);
+                    ms2 = _mm256_fmadd_ps(mvari, mvari, ms2);
+                    }
+                _mm256_store_ps(tmp1, ms1);
+                _mm256_store_ps(tmp2, ms2);
+                for(ssize_t i = 0; i < 8; i++){
+                    s1 += tmp1[i];
+                    s2 += tmp2[i];
+                }
+                s3 = ntime_out;
+            }
+            if (s3 == 0){
+                s1 = 0.;
+                s2 = 0.;
+                __m256 ms0 = _mm256_set1_ps(0.);
+                __m256 ms1 = _mm256_set1_ps(0.);
+                for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
+                    const ssize_t itime_o = iframe_o * 8;
+                    const __m256 mvari = _mm256_load_ps(intensity + itime_o);
+                    ms1 = _mm256_add_ps(mvari, ms1);
+                    ms2 = _mm256_fmadd_ps(mvari, mvari, ms2);
+                    }
+                    _mm256_store_ps(tmp1, ms1);
+                    _mm256_store_ps(tmp2, ms2);
+                    s3 = float(pstate->ntime_out);
+                    for(ssize_t i = 0; i < 8; i++){
+                        s1 += tmp1[i];
+                        s2 += tmp2[i];
+                    }
             }
 
             // auto t22 = std::chrono::high_resolution_clock::now();
@@ -529,9 +581,9 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             // wdur += tmp1.count();
 
             // compute the relevant statistics
-            const float fmean = s1 / float(pstate->ntime_out);
-            const float f2mean = s2 / float(pstate->ntime_out);
-            const float fvar = (float(pstate->ntime_out) / float(pstate->ntime_out -1)) * (f2mean - fmean * fmean);
+            const float fmean = s1 / s3;
+            const float f2mean = s2 / s3;
+            const float fvar = (s3 / (s3 -1)) * (f2mean - fmean * fmean);
 
             (*tmp_mean)[ifreq]= fmean;
             (*tmp_var)[ifreq] = fvar;

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -501,13 +501,13 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 ms3 = _mm256_add_ps(mmask, ms3);
 
                 // compute mask
-                // __m256i mvarw = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
-                // mvarw = _mm256_srlv_epi32(mvarw, shift_ds); // divide by downsampling factor
-                // mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift0), 177));
-                // mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
-                // mvarw = _mm256_add_epi32(mvarw, _mm256_sllv_epi32(_mm256_permute2f128_si256(mvarw, mvarw, 1), shift2));
+                __m256i mvarw = _mm256_cvtps_epi32(_mm256_load_ps(ds_wc + itime_o));
+                mvarw = _mm256_srlv_epi32(mvarw, shift_ds); // divide by downsampling factor
+                mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift0), 177));
+                mvarw = _mm256_add_epi32(mvarw, _mm256_shuffle_epi32(_mm256_sllv_epi32(mvarw, shift1), 2));
+                mvarw = _mm256_add_epi32(mvarw, _mm256_sllv_epi32(_mm256_permute2f128_si256(mvarw, mvarw, 1), shift2));
 
-                // _mm256_store_si256((__m256i*) tmp0, mvarw);
+                _mm256_store_si256((__m256i*) tmp0, mvarw);
                 // uint8_t mask_byte = 0;
                 // for(ssize_t itime_i = 0; itime_i < 8; itime_i++){
                     // const uint8_t w = ((uint8_t) ds_wc[itime_o + itime_i]) / (nds_tot);
@@ -515,7 +515,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 // }
                 // std::cout << std::endl;
 
-                // mask_tmp_ar[ifreq * nrow_mask + iframe_o] = (uint8_t) tmp0[0];
+                mask_tmp_ar[ifreq * nrow_mask + iframe_o] = (uint8_t) tmp0[0];
                 // mask_tmp_ar[ifreq * nrow_mask + itime_o] = mask_byte;
                 // std::bitset<8> x((uint8_t) tmp_intrin[0]);
                 // std::bitset<8> y((uint8_t) mask_byte);

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -485,19 +485,23 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             __m256 ms1 = _mm256_set1_ps(0.);
             __m256 ms2 = _mm256_set1_ps(0.);
             __m256 ms3 = _mm256_set1_ps(0.);
-            // const __m128i shift0 = _mm_set_epi32(1,1,1,1);
+
             const __m256i shift_ds = _mm256_set_epi32(log_nds_tot, log_nds_tot, log_nds_tot, log_nds_tot,
                                                       log_nds_tot, log_nds_tot, log_nds_tot, log_nds_tot);
             const __m256i shift0 = _mm256_set_epi32(1,1,1,1,1,1,1,1);
             const __m256i shift1 = _mm256_set_epi32(2,2,2,2,2,2,2,2);
             const __m256i shift2 = _mm256_set_epi32(4,4,4,4,4,4,4,4);
-            const __m256 ones = _mm256_set1_ps(1.);
+            const __m256 zeroes = _mm256_set1_ps(0.);
+            const __m256 ndss_corr = _mm256_set1_ps(nds_tot-1);
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
                 const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
                 // const __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
                 __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
-                mmask = _mm256_min_ps(mmask, ones);
+                // Create array which is 1 for values with full weight and 0 otherwise
+                mmask = _mm256_sub_ps(mmask, ndss_corr);
+                mmask = _mm256_max_ps(mmask, zeroes);
+                // Ideally would perform early stopping if mmask only contains 0, but did not find fast operation
                 ms0 = _mm256_mul_ps(mvari, mmask);
                 ms1 = _mm256_add_ps(ms0, ms1);
                 ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -491,10 +491,13 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
             const __m256i shift0 = _mm256_set_epi32(1,1,1,1,1,1,1,1);
             const __m256i shift1 = _mm256_set_epi32(2,2,2,2,2,2,2,2);
             const __m256i shift2 = _mm256_set_epi32(4,4,4,4,4,4,4,4);
+            __m256 ones = _mm256_set1_ps(1.);
             for(ssize_t iframe_o = 0; iframe_o < ntime_out/8; iframe_o+=1){
                 const ssize_t itime_o = iframe_o * 8;
                 const __m256 mvari = _mm256_load_ps(ds_ic + itime_o);
-                const __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
+                // const __m256 mmask = _mm256_load_ps(ds_wc + itime_o);
+                __m256 mmask = _mm256_load_ps(mask + itime_o);
+                mmask = _mm256_min_ps(mmask, ones);
                 ms0 = _mm256_mul_ps(mvari, mmask);
                 ms1 = _mm256_add_ps(ms0, ms1);
                 ms2 = _mm256_fmadd_ps(ms0, ms0, ms2);

--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -411,7 +411,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
         uint32_t* tmp0 = get_ptr<uint32_t>(tmp_intrin);
         float* tmp1 = get_ptr<float>(tmp_intrinf1);
         float* tmp2 = get_ptr<float>(tmp_intrinf2);
-        float* tmp2 = get_ptr<float>(tmp_intrinf3);
+        float* tmp3 = get_ptr<float>(tmp_intrinf3);
         float fnorm;
 
         // estimate channel mean and var, compute mask
@@ -533,7 +533,7 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
                 s2 += tmp3[i];
             }
 
-            // Repeat calvulation with old scheme if full chunk is masked
+            // Repeat calculation with old scheme if full chunk is masked
             // Could also calculate if chunk if fully masked before the full loop
             // Performance of alternate scheme most likely depends on fraction of fully masked chunks
             if (s3 == 0){

--- a/rf_pipelines_inventory.hpp
+++ b/rf_pipelines_inventory.hpp
@@ -765,6 +765,7 @@ struct chime_slow_pulsar_writer : public wi_transform
     std::shared_ptr<uint32_t> tmp_intrin;
     std::shared_ptr<float> tmp_intrinf1;
     std::shared_ptr<float> tmp_intrinf2;
+    std::shared_ptr<float> tmp_intrinf3;
 
     // huffman state variables associated with ibuf
     ssize_t i0 = 0;


### PR DESCRIPTION
This PR fixes a long standing issue of the slow pulsar writer where strongly outlying values in the recorded intensities will hurt the quantisation of the data. This shows up as additional red noise in the CHAMPSS and Slow data.
This is fixed by only using values that have not been flagged by RFI masking for the calculation of the quantisation levels.

<img width="1054" height="599" alt="image" src="https://github.com/user-attachments/assets/a0250128-9834-40f9-9423-07089623100b" />
In this chunk for example, some outlying (very low) values will distort the quantisation in such a way, that the actual used values ("Masked" in the bottom right histogram) only show up in two levels.
After the fix the histogram looks much more useful consistently. For example:
<img width="632" height="439" alt="image" src="https://github.com/user-attachments/assets/abd7130d-9dce-41f0-ba84-7e40f95303a2" />

The essential operation of this PR is
```ms0 = _mm256_mul_ps(mvari, mmask_f);```
The other changes facilitate this change and make sure that the means and variances are properly calculated.

In order to prepare the mask value for multiplication I moved the mask calculation before the calculation of the means and squares. This also allows skipping some iterations where segments are fully masked.

I took the liberty of removing some old commented out code which were old versions of performing similar calculations and adding some comments.

I think the performance should be comparable with the old version. Probably a bit slower. There are additional calculations but some steps are skipped in partially masked chunks. 
(In my dummy test script testing these methods on fake data the loop calculating the mask and means was about 10% slower.)

I am currently testing to see if recording many beams from the same node retains the same level of stability as before.

@dstndstn 