### PR TITLE
Comment out slow pulsar performance logging

### DIFF
--- a/chime_slow_pulsar_writer.cpp
+++ b/chime_slow_pulsar_writer.cpp
@@ -599,14 +599,14 @@ void chime_slow_pulsar_writer::_process_chunk(float *intensity, ssize_t istride,
         std::chrono::duration<double> tdownsample = t1 - t0;
         std::chrono::duration<double> tloop = t3 - t2;
         std::chrono::duration<double> twrite = t4 - t3;
-        std::cout << "time per exec: " << this->time_spent_in_transform / ichunk << std::endl;
-        std::cout << "\tdownsample: " << tdownsample.count() << std::endl;
-        std::cout << "\tloop: " << tloop.count() << std::endl;
+        // std::cout << "time per exec: " << this->time_spent_in_transform / ichunk << std::endl;
+        // std::cout << "\tdownsample: " << tdownsample.count() << std::endl;
+        // std::cout << "\tloop: " << tloop.count() << std::endl;
         // std::cout << "\t\tweight_loop: " << wdur << std::endl;
         // std::cout << "\t\tnorm_loop: " << ndur << std::endl;
         // std::cout << "\t\tquantize_loop: " << qdur << std::endl;
         // std::cout << "\t\tcompress_loop: " << cdur << std::endl;
-        std::cout << "\twrite: " << twrite.count() << std::endl;
+        // std::cout << "\twrite: " << twrite.count() << std::endl;
     }
 
 


### PR DESCRIPTION
Currently the logs of the L1 nodes are dominated by the logs created from the slow pulsar writer, which causes the logs for a few nodes only spanning a few days before they are cycled out.
I commented out the responsible logs in this PR.
I have not tested it, but it should be fine, due to the minimal nature of the change.

Current example of the logs:
<img width="1273" height="671" alt="image" src="https://github.com/user-attachments/assets/274f504b-668f-455e-b8ad-881bf4dec691" />
